### PR TITLE
Added timeout_func keyword param

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -82,3 +82,13 @@ def test_nonnumeric_numsec_timedelta_via_string():
     with pytest.raises(TimedOutError):
         wait_for(func,
                  timeout="2s", delay=1)
+
+
+def test_timeout_func():
+    incman = Incrementor()
+
+    result = wait_for(
+        lambda: incman.i_sleep_a_lot() > 10,
+        num_sec=1, message="lambda_long_wait",
+        timeout_func=lambda: "Success")
+    assert result == "Success", "wait_for should return a string"

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -109,6 +109,7 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
         delay: An integer describing the number of seconds to delay before trying func()
             again.
         fail_func: A function to be run after every unsuccessful attempt to run func()
+        timeout_func: A function to be run after timeout instead of raising ``TimedOutError``
         quiet: Do not write time report to the log (default False)
         very_quiet: Do not log unless there was an error (default False). Implies quiet.
         silent_failure: Even if the entire attempt times out, don't throw a exception.
@@ -131,6 +132,7 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
     handle_exception = kwargs.get('handle_exception', False)
     delay = kwargs.get('delay', 1)
     fail_func = kwargs.get('fail_func', None)
+    timeout_func = kwargs.get('timeout_func', None)
     very_quiet = kwargs.get("very_quiet", False)
     quiet = kwargs.get("quiet", False) or very_quiet
     silent_fail = kwargs.get("silent_failure", False)
@@ -177,7 +179,11 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
         logger.error("Couldn't complete {} at {}:{} in time, took {:0.2f}, {} tries".format(message,
             filename, line_no, t_delta, tries))
         logger.error('The last result of the call was: {}'.format(out))
-        raise TimedOutError("Could not do {} at {}:{} in time".format(message, filename, line_no))
+        if timeout_func:
+            return timeout_func()
+        else:
+            raise TimedOutError("Could not do {} at {}:{} in time".format(
+                                message, filename, line_no))
     else:
         logger.warning("Could not do {} at {}:{} in time ({} tries) but ignoring".format(message,
             filename, line_no, tries))


### PR DESCRIPTION
It would be nice to have the possibility to execute some function after timeout instead of raising an exception.
Example of usage:
```python
wait_for(some_func, timeout_func=some_timeout_func)
```
Currently it can be achieved by this way:
```python
try:
    wait_for(some_func)
except TimedOutError:
    some_timeout_func()
```