### PR TITLE
Show the source of the lambda funciton on failure.

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,6 +5,11 @@ import time
 from functools import partial
 from wait_for import wait_for, wait_for_decorator, TimedOutError
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 
 class Incrementor():
     value = 0
@@ -38,6 +43,26 @@ def test_lambda_long_wait():
     with pytest.raises(TimedOutError):
         wait_for(lambda self: self.i_sleep_a_lot() > 10, [incman],
                  num_sec=1, message="lambda_long_wait")
+
+
+@patch('wait_for.default_hidden_logger.error')
+def test_lambda_default_message_from_src(error_logger):
+    incman = Incrementor()
+    with pytest.raises(TimedOutError) as excinfo:
+        wait_for(lambda self: self.i_sleep_a_lot() > 10, [incman],
+                 num_sec=1)
+
+    # Check we got the lamda code in the TimedOutError
+    expected_message_content = "lambda self: self.i_sleep_a_lot() > 10"
+    assert expected_message_content in str(excinfo.value)
+
+    # Check we got the lamda code in the error log
+    error_log_messages = [call[0][0] for call in error_logger.call_args_list]
+    for message in error_log_messages:
+        if expected_message_content in message:
+            break
+    else:
+        pytest.fail("The error log doesn't contain a message with code of the lambda function")
 
 
 def test_partial():

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps=
     pytest
     pytest-cov
     coveralls
+    mock
 commands = py.test {posargs: tests/ -v --cov wait_for}
 
 [testenv:codechecks]

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -126,6 +126,9 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
     Raises:
         TimedOutError: If num_sec is exceeded after an unsuccessful func() invocation.
     """
+    # Hide this call in the detailed traceback
+    # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
+    __tracebackhide__ = True
     logger = logger or default_hidden_logger
     st_time = time.time()
     total_time = 0

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -6,6 +6,8 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from functools import partial
 from threading import Timer
+from types import LambdaType
+import inspect
 
 import parsedatetime
 
@@ -44,6 +46,10 @@ def _get_timeout_secs(kwargs):
     return num_sec
 
 
+def is_lambda_function(obj):
+    return isinstance(obj, LambdaType) and obj.__name__ == "<lambda>"
+
+
 def _get_context(func, message=None):
     if isinstance(func, partial):
         f_code = six.get_function_code(func.func)
@@ -57,7 +63,10 @@ def _get_context(func, message=None):
         line_no = f_code.co_firstlineno
         filename = f_code.co_filename
         if not message:
-            message = "function %s()" % func.__name__
+            if is_lambda_function(func):
+                message = 'lambda defined as `{}`'.format(inspect.getsource(func).strip())
+            else:
+                message = "function %s()" % func.__name__
     return f_code, line_no, filename, message
 
 


### PR DESCRIPTION
In case we are waiting for lambda function and we timeout, show its code instead of showing just `Could not do function <lambda>() at /var/ci/workspace/downstream-510z-tests-master/integration_tests/cfme/infrastructure/host.py:422 in time`
it will show
```
In [2]: wait_for.wait_for(lambda: False, num_sec=1)
---------------------------------------------------------------------------
TimedOutError                             Traceback (most recent call last)
<ipython-input-2-cb385f65eec5> in <module>()
----> 1 wait_for.wait_for(lambda: False, num_sec=1)

/home/jhenner/work/wait_for/wait_for/__init__.py in wait_for(func, func_args, func_kwargs, logger, **kwargs)
    190             filename, line_no, t_delta, tries))
    191         logger.error('The last result of the call was: {}'.format(out))
--> 192         raise TimedOutError("Could not do {} at {}:{} in time".format(message, filename, line_no))
    193     else:
    194         logger.warning("Could not do {} at {}:{} in time ({} tries) but ignoring".format(message,

TimedOutError: Could not do lambda defined as `wait_for.wait_for(lambda: False, num_sec=1)` at <ipython-input-2-cb385f65eec5>:1 in time


```