### PR TITLE
 Fix message when lambda defined in interactive shell 

### DIFF
--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -64,7 +64,13 @@ def _get_context(func, message=None):
         filename = f_code.co_filename
         if not message:
             if is_lambda_function(func):
-                message = 'lambda defined as `{}`'.format(inspect.getsource(func).strip())
+                try:
+                    message = 'lambda defined as `{}`'.format(inspect.getsource(func).strip())
+                except IOError as ioerror:
+                    # We are probably in interactive python shell or debugger,
+                    # we cannot get source of the lambda.
+                    message = ("lambda (Couldn't get it's source code."
+                               "Perhaps it is defined in interactive shell.)").format(ioerror)
             else:
                 message = "function %s()" % func.__name__
     return f_code, line_no, filename, message


### PR DESCRIPTION
When in `ipdb` or `pdb` and executed `wait_for` with lambda defined from cmdline, the wait_for could fail like this without actually trying to execute the lambda at all:
```
(Pdb++) wait_for(lambda: navigate_to(app.server, 'MyServiceAll'), num_sec=60)
*** IOError: could not get source code
```

Catching the IOError when getting it's source code and filling the message with some info instead of propagating IOError will cause the `wait_for` really try to execute the lambda and if it won't succeed, the exception thrown will be like this:
```
ipdb> wait_for.wait_for(lambda: False, num_sec=.1)                                                        
*** wait_for.TimedOutError: Could not do lambda (and couldn't get it's source code) at <stdin>:1 in time
```