### PR TITLE
silent_failure also returns the result

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -38,6 +38,17 @@ def test_lambda_wait():
     assert tc < 2, "Should take less than 2 seconds"
 
 
+def test_lambda_wait_silent_fail():
+    incman = Incrementor()
+    ec, tc = wait_for(lambda self: self.i_sleep_a_lot() > 100,
+                      [incman],
+                      delay=.05,
+                      num_sec=1,
+                      silent_failure=True)
+    print("Function output {} in time {} ".format(ec, tc))
+    assert tc == 1, "Should be num_sec"
+
+
 def test_lambda_long_wait():
     incman = Incrementor()
     with pytest.raises(TimedOutError):

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -155,6 +155,7 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
 
     t_delta = 0
     tries = 0
+    out = None
     if not very_quiet:
         logger.debug('Started {} at {}'.format(message, st_time))
     while t_delta <= num_sec:
@@ -200,6 +201,7 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
         logger.warning("Could not do {} at {}:{} in time ({} tries) but ignoring".format(message,
             filename, line_no, tries))
         logger.warning('The last result of the call was: {}'.format(out))
+        return WaitForResult(out, num_sec)
 
 
 def wait_for_decorator(*args, **kwargs):


### PR DESCRIPTION
Hello guys, I found this feature useful and there is no reason why not to return the value in case of silent failure. I can handle the data more specifically myself after `wait_for`