### PR TITLE
Drop py27 and py33 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: xenial
 language: python
 python:
-  - "2.7"
-  - '3.4'
   - '3.5'
+  - '3.6'
+  - '3.7'
 install: pip install tox-travis
 script: tox
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-parsedatetime
-six
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,14 +10,18 @@ classifier =
     Environment :: Console
     Intended Audience :: Developers
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Utilities
 keywords =
     setup
     distutils
+
+[options]
+install_requires =
+    parsedatetime
 
 [files]
 packages =

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=W0621
+from unittest.mock import patch
 import pytest
 import time
 from functools import partial
 from wait_for import wait_for, wait_for_decorator, TimedOutError
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 
 class Incrementor():

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py{27,33,34,35,36,37},codechecks
+envlist = py{35,36,37},codechecks
 
 [testenv]
+usedevelop = true
 deps=
     pytest
     pytest-cov
@@ -11,17 +12,15 @@ commands = py.test {posargs: tests/ -v --cov wait_for}
 
 [testenv:codechecks]
 skip_install = true
-deps= flake8
+deps = flake8
 commands = flake8 {posargs:wait_for tests}
 
 [flake8]
 max_line_length = 100
 ignore = E128,E811
 
-[tox:travis]
-2.7 = py27, codechecks
-3.3 = py33
-3.4 = py34
-3.5 = py35
-3.6 = py36
-3.7 = py37
+[travis]
+python =
+  3.5: py35
+  3.6: py36
+  3.7: py37,codechecks

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 import time
 import logging
 from collections import namedtuple
@@ -19,12 +18,8 @@ default_hidden_logger = logging.getLogger('wait_for.default')
 default_hidden_logger.propagate = False
 default_hidden_logger.addHandler(logging.NullHandler())
 
-try:
-    # Available in 3.3+
-    get_time = time.monotonic
-except AttributeError:
-    # Fall back
-    get_time = time.time
+# Available in 3.3+
+get_time = time.monotonic
 
 
 def _parse_time(t):
@@ -42,7 +37,7 @@ def _get_timeout_secs(kwargs):
         timeout = kwargs["timeout"]
         if isinstance(timeout, (int, float)):
             num_sec = float(timeout)
-        elif isinstance(timeout, six.string_types):
+        elif isinstance(timeout, str):
             num_sec = _parse_time(timeout)
         elif isinstance(timeout, timedelta):
             num_sec = timeout.total_seconds()
@@ -59,14 +54,14 @@ def is_lambda_function(obj):
 
 def _get_context(func, message=None):
     if isinstance(func, partial):
-        f_code = six.get_function_code(func.func)
+        f_code = func.func.__code__
         line_no = f_code.co_firstlineno
         filename = f_code.co_filename
         if not message:
             params = ", ".join([str(arg) for arg in func.args])
             message = "partial function %s(%s)" % (func.func.__name__, params)
     else:
-        f_code = six.get_function_code(func)
+        f_code = func.__code__
         line_no = f_code.co_firstlineno
         filename = f_code.co_filename
         if not message:


### PR DESCRIPTION
Remove py27 and py33 from tox, travis, packaging
Clean up imports that were different between python versions
remove requirements.txt, move to setup.py
remove uses of six library for direct py3 built-ins