### PR TITLE
make num_sec to be converted to float

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -118,3 +118,11 @@ def test_nonnumeric_numsec_timedelta_via_string():
     with pytest.raises(TimedOutError):
         wait_for(func,
                  timeout="2s", delay=1)
+
+
+def test_str_numsec():
+    incman = Incrementor()
+    func = partial(lambda: incman.i_sleep_a_lot() > 10)
+    for value in "2", "1.5":
+        with pytest.raises(TimedOutError):
+            wait_for(func, num_sec=value)

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -49,7 +49,7 @@ def _get_timeout_secs(kwargs):
         else:
             raise ValueError("Timeout got an unknown value {}".format(timeout))
     else:
-        num_sec = kwargs.get('num_sec', 120)
+        num_sec = float(kwargs.get('num_sec', 120))
     return num_sec
 
 


### PR DESCRIPTION
it was auto converted to int in py2 but it doesn't work on py3. let's add explicit float conversion since it's handy and won't make us fix this issue in other projects