### PR TITLE
wrong logging debug formatter fix

### DIFF
--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -167,7 +167,7 @@ def wait_for(func, func_args=[], func_kwargs={}, logger=None, **kwargs):
     tries = 0
     out = None
     if not very_quiet:
-        logger.debug("Started %(message)r at %(time)", {'message': message, 'time': st_time})
+        logger.debug("Started %(message)r at %(time).2f", {'message': message, 'time': st_time})
     while t_delta <= num_sec:
         tries += 1
         if log_on_loop:


### PR DESCRIPTION
fixes bug introduced in 344270e

(this is how bug manifested)
`>>> 'Started %(message)r at %(time)' % {'message': 'function _wait_for_pcap_to_appear()', 'time': 205755.13175536}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: incomplete format
`