### PR TITLE
Fix formatting InvocationError

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ ignore = E128,E811
 
 [travis]
 python =
-  3.5: py35
-  3.6: py36
+  3.5: py35,codechecks
+  3.6: py36,codechecks
   3.7: py37,codechecks

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -72,7 +72,7 @@ def _get_context(func, message=None):
                     # We are probably in interactive python shell or debugger,
                     # we cannot get source of the lambda.
                     message = ("lambda (Couldn't get it's source code."
-                               "Perhaps it is defined in interactive shell.)").format(ioerror)
+                               "Perhaps it is defined in interactive shell: {})").format(ioerror)
             else:
                 message = "function %s()" % func.__name__
     return f_code, line_no, filename, message


### PR DESCRIPTION
```
codechecks run-test: commands[0] | flake8 wait_for tests

wait_for/__init__.py:74:32: F523 '...'.format(...) has unused arguments at position(s): 0

ERROR: InvocationError for command /home/travis/build/RedHatQE/wait_for/.tox/codechecks/bin/flake8 wait_for tests (exited with code 1)
```