### PR TITLE
[RFR] Allow builtin / C module functions

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -21,7 +21,7 @@ def test_simple_wait():
     ec, tc = wait_for(incman.i_sleep_a_lot,
                       fail_condition=0,
                       delay=.05)
-    print("Function output {} in time {} ".format(ec, tc))
+    print("Function output {} in time {}".format(ec, tc))
     assert tc < 1, "Should take less than 1 seconds"
 
 
@@ -30,7 +30,14 @@ def test_lambda_wait():
     ec, tc = wait_for(lambda self: self.i_sleep_a_lot() > 10,
                       [incman],
                       delay=.05)
-    print("Function output {} in time {} ".format(ec, tc))
+    print("Function output {} in time {}".format(ec, tc))
+    assert tc < 2, "Should take less than 2 seconds"
+
+
+def test_builtin_wait():
+    incman = Incrementor()
+    ec, tc = wait_for(bool, [incman], delay=0.5)
+    print("Function output {} in time {}".format(ec, tc))
     assert tc < 2, "Should take less than 2 seconds"
 
 
@@ -41,7 +48,7 @@ def test_lambda_wait_silent_fail():
                       delay=.05,
                       num_sec=1,
                       silent_failure=True)
-    print("Function output {} in time {} ".format(ec, tc))
+    print("Function output {} in time {}".format(ec, tc))
     assert tc == 1, "Should be num_sec"
 
 
@@ -94,7 +101,7 @@ def test_wait_decorator():
     @wait_for_decorator(fail_condition=0, delay=.05)
     def a_test():
         incman.i_sleep_a_lot()
-    print("Function output {} in time {} ".format(a_test.out, a_test.duration))
+    print("Function output {} in time {}".format(a_test.out, a_test.duration))
     assert a_test.duration < 1, "Should take less than 1 seconds"
 
 
@@ -104,7 +111,7 @@ def test_wait_decorator_noparams():
     @wait_for_decorator()
     def a_test():
         return incman.i_sleep_a_lot() != 0
-    print("Function output {} in time {} ".format(a_test.out, a_test.duration))
+    print("Function output {} in time {}".format(a_test.out, a_test.duration))
     assert a_test.duration < 1, "Should take less than 1 seconds"
 
 


### PR DESCRIPTION
Allow builtins and other functions (e.g., those imported from modules written in C) that do not have the `__code__` attribute.

Fixes https://github.com/RedHatQE/wait_for/issues/17