### PR TITLE
Limit total time to timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: python-${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,9 @@ exception handling during ``func()`` invocation.
 ``handle_exception`` is active, re-raises the last original exception instead of
 ``TimedOutError``. Default: ``False``.
 
-``fail_func`` *(callable | None)* -- A callback invoked after every failed attempt
-(after sleeping). Useful for cleanup or logging side-effects. Default: ``None``.
+``fail_func`` *(callable | None)* -- A callback invoked after every failed attempt,
+including when the timeout budget is already exhausted and no sleep occurs.
+Useful for cleanup or logging side-effects. Default: ``None``.
 
 ``quiet`` *(bool)* -- Suppress the ``"Took X to do Y"`` debug log emitted on a successful
 return. Default: ``False``. Note: the secondary ``"Finished ..."`` debug message emitted

--- a/tests/test_wait_for.py
+++ b/tests/test_wait_for.py
@@ -223,6 +223,24 @@ def test_fail_func() -> None:
     assert fail_func.call_count >= 1
 
 
+def test_fail_func_called_when_func_exhausts_timeout() -> None:
+    """``fail_func`` is invoked even when ``func()`` itself consumes the timeout budget.
+
+    The ``remaining <= 0`` early-exit branch must call ``fail_func`` before
+    breaking, preserving the same callback behavior the original loop had
+    (which had no early break and always reached ``fail_func``).
+    """
+    fail_func = MagicMock()
+
+    def slow_fail() -> bool:
+        time.sleep(0.3)
+        return False
+
+    with pytest.raises(TimedOutError):
+        wait_for(slow_fail, fail_func=fail_func, num_sec=0.1, delay=0)
+    assert fail_func.call_count == 1
+
+
 # ---------------------------------------------------------------------------
 # Error and message reporting
 # ---------------------------------------------------------------------------

--- a/tests/test_wait_for.py
+++ b/tests/test_wait_for.py
@@ -380,3 +380,48 @@ def test_wait_for_result_unpacking() -> None:
     out, duration = wait_for(_always_true, num_sec=1)
     assert out is True
     assert isinstance(duration, float)
+
+
+# ---------------------------------------------------------------------------
+# Sleep overshoot capping
+# ---------------------------------------------------------------------------
+
+
+def test_expo_sleep_does_not_overshoot_timeout() -> None:
+    """With ``expo=True``, elapsed time must not significantly exceed ``num_sec``.
+
+    The exponential delay doubles each iteration and can grow well past the
+    remaining time budget.  The wait loop should cap each sleep to the time
+    left so the total wall-clock duration stays close to ``num_sec``.
+    """
+    num_sec = 2.0
+    tolerance = 0.5
+    _, duration = wait_for(
+        _always_false,
+        expo=True,
+        delay=0.1,
+        num_sec=num_sec,
+        silent_failure=True,
+    )
+    assert duration <= num_sec + tolerance, (
+        f"Expected <= {num_sec + tolerance}s, but waited {duration:.2f}s"
+    )
+
+
+def test_large_fixed_delay_does_not_overshoot_timeout() -> None:
+    """A fixed ``delay`` larger than ``num_sec`` must not cause a long overshoot.
+
+    When delay exceeds the remaining budget, the sleep should be capped so
+    the total elapsed time stays close to ``num_sec``.
+    """
+    num_sec = 0.5
+    tolerance = 0.5
+    _, duration = wait_for(
+        _always_false,
+        delay=10,
+        num_sec=num_sec,
+        silent_failure=True,
+    )
+    assert duration <= num_sec + tolerance, (
+        f"Expected <= {num_sec + tolerance}s, but waited {duration:.2f}s"
+    )

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -186,7 +186,8 @@ def wait_for(
         raise_original (bool): Controls if last original exception would be raised on timeout
         delay (int): An integer describing the number of seconds to delay before trying func()
             again.
-        fail_func (callable): A function to be run after every unsuccessful attempt to run func()
+        fail_func (callable): A function to be run after every unsuccessful attempt to run func(),
+            including when the timeout budget is already exhausted and no sleep occurs.
         quiet (Any): Suppress the "Took X to do Y" debug log emitted on success (default False).
             Note: the secondary "Finished ..." debug log on success is only suppressed by
             very_quiet, not quiet alone.
@@ -271,6 +272,9 @@ def wait_for(
             t_delta = time.monotonic() - st_time
             remaining = num_sec - t_delta
             if remaining <= 0:
+                if fail_func:
+                    fail_func()
+                    t_delta = time.monotonic() - st_time
                 break
             time.sleep(min(delay, remaining))
             if expo:

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -268,7 +268,11 @@ def wait_for(
                 )
                 raise
         if out is fail_condition or fail_condition_check(out):
-            time.sleep(delay)
+            t_delta = time.monotonic() - st_time
+            remaining = num_sec - t_delta
+            if remaining <= 0:
+                break
+            time.sleep(min(delay, remaining))
             if expo:
                 delay *= 2
             if fail_func:


### PR DESCRIPTION
Check remaining time so that the total timeout isn't overrun

add test coverage

FIXES #43 