### PR TITLE
Drop parsedatetime dependency and num_sec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_schedule: monthly
-
+  autofix_prs: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,3 @@ repos:
     hooks:
       - id: mypy
         files: ^wait_for/
-        additional_dependencies: [parsedatetime>=2.5]

--- a/README.rst
+++ b/README.rst
@@ -278,7 +278,7 @@ Use a ``datetime.timedelta`` for the timeout value:
 
    from datetime import timedelta
 
-   func = partial(lambda: incman.i_sleep_a_lot() > 10)
+   func = lambda: incman.i_sleep_a_lot() > 10
    result, elapsed = wait_for(func, timeout=timedelta(minutes=5), delay=1)
 
 Exponential backoff

--- a/README.rst
+++ b/README.rst
@@ -65,14 +65,9 @@ a hidden logger (``wait_for.default``) that discards output.
 
 **Keyword-only arguments (passed via** ``**kwargs`` **):**
 
-``num_sec`` *(int | float)* -- Maximum number of seconds to wait before timing out.
-Default: ``120``. Ignored when ``timeout`` is provided.
-
-``timeout`` *(int | float | timedelta | str)* -- Maximum time to wait before timing out.
-Accepts an ``int``/``float`` (seconds), a ``datetime.timedelta`` object, or a
-human-readable string parsed by `parsedatetime <https://pypi.org/project/parsedatetime/>`_
-(e.g. ``"1h 10m 5s"``, ``"2 minutes"``). When provided, this takes precedence
-over ``num_sec``.
+``timeout`` *(int | float | timedelta)* -- Maximum time to wait before timing out.
+Accepts an ``int``/``float`` (seconds) or a ``datetime.timedelta`` object.
+Default: ``120`` seconds when not provided.
 
 ``delay`` *(int | float)* -- Seconds to sleep between attempts. Default: ``1``.
 
@@ -171,7 +166,7 @@ All keyword arguments accepted by ``wait_for`` can be passed to the decorator.
 
    from wait_for import wait_for_decorator
 
-   @wait_for_decorator(num_sec=120, fail_condition=0, delay=0.05)
+   @wait_for_decorator(timeout=120, fail_condition=0, delay=0.05)
    def my_waiting_func():
        return do_something()
 
@@ -274,24 +269,16 @@ Pass arguments to a lambda and wait until the condition is met:
        delay=0.05
    )
 
-Human-readable timeout strings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Timeout with timedelta
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Use natural language for the timeout value:
-
-.. code-block:: python
-
-   from functools import partial
-
-   func = partial(lambda: incman.i_sleep_a_lot() > 10)
-   result, elapsed = wait_for(func, timeout="2s", delay=1)
-
-The ``timeout`` parameter also accepts ``datetime.timedelta`` objects:
+Use a ``datetime.timedelta`` for the timeout value:
 
 .. code-block:: python
 
    from datetime import timedelta
 
+   func = partial(lambda: incman.i_sleep_a_lot() > 10)
    result, elapsed = wait_for(func, timeout=timedelta(minutes=5), delay=1)
 
 Exponential backoff
@@ -305,7 +292,7 @@ Double the delay after each failed attempt:
        my_flaky_function,
        delay=1,
        expo=True,
-       num_sec=120
+       timeout=120
    )
 
 Exception handling
@@ -321,20 +308,20 @@ Catch exceptions during waiting and convert them to retries:
    result, elapsed = wait_for(
        might_raise,
        handle_exception=True,
-       num_sec=30
+       timeout=30
    )
 
    # Catch only specific exception types
    result, elapsed = wait_for(
        might_raise,
        handle_exception=(ConnectionError, TimeoutError),
-       num_sec=30
+       timeout=30
    )
 
    # Re-raise the original exception instead of TimedOutError
    try:
        wait_for(might_raise, handle_exception=True,
-                num_sec=5, raise_original=True)
+                timeout=5, raise_original=True)
    except ConnectionError:
        print("Original exception re-raised")
 
@@ -349,7 +336,7 @@ Use a function to define complex failure logic:
    result, elapsed = wait_for(
        incman.i_sleep_a_lot,
        fail_condition=lambda value: value <= 10,
-       num_sec=30,
+       timeout=30,
        delay=0.1
    )
 
@@ -362,10 +349,10 @@ Return the last result instead of raising on timeout:
 
    result, elapsed = wait_for(
        lambda: some_check(),
-       num_sec=5,
+       timeout=5,
        silent_failure=True
    )
-   # result contains the last return value; elapsed == num_sec
+   # result contains the last return value; elapsed == timeout
 
 Decorator usage
 ~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 requires-python = ">=3.10"
-dependencies = [
-    "parsedatetime>=2.5",
-]
+dependencies = []
 dynamic = ["version"]
 
 [project.urls]
@@ -72,7 +70,3 @@ warn_return_any = true
 warn_unused_configs = true
 
 exclude = ["tests/"]
-
-[[tool.mypy.overrides]]
-module = "parsedatetime"
-ignore_missing_imports = true

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -47,7 +47,7 @@ def test_handle_exception_v3():
     ``TimedOutError`` should be raised instead.
     """
     with pytest.raises(TimedOutError):
-        wait_for(raise_(MyError), handle_exception=True, num_sec=0.1)
+        wait_for(raise_(MyError), handle_exception=True, timeout=0.1)
 
 
 def test_handle_exception_raises_TimedOutError_from_occured_exception():
@@ -57,7 +57,7 @@ def test_handle_exception_raises_TimedOutError_from_occured_exception():
     ``TimedOutError`` should be raised from function-occurred exception instead.
     """
     try:
-        wait_for(raise_(MyError), handle_exception=True, num_sec=0.1)
+        wait_for(raise_(MyError), handle_exception=True, timeout=0.1)
     except TimedOutError as timeout_exception:
         assert isinstance(timeout_exception.__cause__, MyError)
     else:
@@ -71,7 +71,7 @@ def test_handle_specific_exception():
     ``TimedOutError`` should be raised.
     """
     with pytest.raises(TimedOutError):
-        wait_for(raise_(MyError), handle_exception=MyError, num_sec=0.1)
+        wait_for(raise_(MyError), handle_exception=MyError, timeout=0.1)
 
 
 def test_handle_specific_exception_in_iterable():
@@ -81,7 +81,7 @@ def test_handle_specific_exception_in_iterable():
     ``TimedOutError`` should be raised.
     """
     with pytest.raises(TimedOutError):
-        wait_for(raise_(MyError), handle_exception=(MyError,), num_sec=0.1)
+        wait_for(raise_(MyError), handle_exception=(MyError,), timeout=0.1)
 
 
 def test_handle_specific_exception_from_general_one():
@@ -91,7 +91,7 @@ def test_handle_specific_exception_from_general_one():
     ``TimedOutError`` should be raised.
     """
     with pytest.raises(TimedOutError):
-        wait_for(raise_(MyError), handle_exception=(Exception,), num_sec=0.1)
+        wait_for(raise_(MyError), handle_exception=(Exception,), timeout=0.1)
 
 
 def test_handle_specific_exceptions_in_iterable():
@@ -107,7 +107,7 @@ def test_handle_specific_exceptions_in_iterable():
                 MyError,
                 AnotherError,
             ),
-            num_sec=0.1,
+            timeout=0.1,
         )
 
 
@@ -137,7 +137,7 @@ def test_handle_exception_in_iterable_containing_not_exception_types_are_interpr
                 MyError, AnotherError, MyError(), AnotherError(), RuntimeError, RuntimeError("Foo")
             ),
             handle_exception=handle_exception,
-            num_sec=1,
+            timeout=1,
             delay=0.1,
         )
 
@@ -157,7 +157,7 @@ def test_handle_exceptions_in_empty_iterable_are_interpreted_as_False(handle_exc
     An exception raised by the waited-upon function should bubble up.
     """
     with pytest.raises(MyError):
-        wait_for(raise_(MyError), handle_exception=handle_exception, num_sec=1, delay=0.1)
+        wait_for(raise_(MyError), handle_exception=handle_exception, timeout=1, delay=0.1)
 
 
 def test_not_handle_unexpected_exception():
@@ -167,7 +167,7 @@ def test_not_handle_unexpected_exception():
     ``AnotherError`` should be raised.
     """
     with pytest.raises(AnotherError):
-        wait_for(raise_(AnotherError), handle_exception=MyError, num_sec=0.1)
+        wait_for(raise_(AnotherError), handle_exception=MyError, timeout=0.1)
 
 
 def test_not_handle_unexpected_exceptions():
@@ -183,7 +183,7 @@ def test_not_handle_unexpected_exceptions():
                 ValueError,
                 RuntimeError,
             ),
-            num_sec=0.1,
+            timeout=0.1,
         )
 
 
@@ -192,16 +192,16 @@ def test_handle_exception_silent_failure():
 
     The time spent calling the waited-upon function should be returned.
     """
-    _, num_sec = wait_for(
+    _, duration = wait_for(
         raise_(MyError),
         handle_exception=True,
-        num_sec=0.1,
+        timeout=0.1,
         silent_failure=True,
     )
-    assert isinstance(num_sec, float)
+    assert isinstance(duration, float)
 
 
 def test_reraise_exception():
     """Original exception is re-raised"""
     with pytest.raises(MyError):
-        wait_for(raise_(MyError), handle_exception=True, num_sec=0.1, raise_original=True)
+        wait_for(raise_(MyError), handle_exception=True, timeout=0.1, raise_original=True)

--- a/tests/test_wait_for.py
+++ b/tests/test_wait_for.py
@@ -2,7 +2,7 @@
 
 Organised by concept:
 - Function type variants (method, lambda, builtin, partial)
-- timeout / num_sec parameter variants
+- timeout parameter variants
 - fail_condition variants (default, callable, set)
 - Optional parameters (silent_failure, log_on_loop, expo, fail_func)
 - Error and message reporting
@@ -57,7 +57,7 @@ def _always_true() -> bool:
 def test_method_as_func() -> None:
     """A regular bound method is accepted as the waited-upon function."""
     incman = Incrementor()
-    out, elapsed = wait_for(incman.increment_with_sleep, fail_condition=0, delay=0.05, num_sec=2)
+    out, elapsed = wait_for(incman.increment_with_sleep, fail_condition=0, delay=0.05, timeout=2)
     assert out == 1
     assert elapsed < 1
 
@@ -66,7 +66,7 @@ def test_lambda_as_func() -> None:
     """A lambda expression is accepted as the waited-upon function."""
     incman = Incrementor()
     out, elapsed = wait_for(
-        lambda self: self.increment_with_sleep() > 10, [incman], delay=0.05, num_sec=5
+        lambda self: self.increment_with_sleep() > 10, [incman], delay=0.05, timeout=5
     )
     assert out is True
     assert elapsed < 2
@@ -75,21 +75,21 @@ def test_lambda_as_func() -> None:
 def test_builtin_as_func() -> None:
     """A C builtin (bool) is accepted as the waited-upon function."""
     incman = Incrementor()
-    out, elapsed = wait_for(bool, [incman], delay=0.5, num_sec=2)
+    out, elapsed = wait_for(bool, [incman], delay=0.5, timeout=2)
     assert out is True
     assert elapsed < 2
 
 
 def test_callable_object_as_func() -> None:
     """A callable object (instance with __call__) is accepted as the waited-upon function."""
-    result = wait_for(CallableObject(), num_sec=1)
+    result = wait_for(CallableObject(), timeout=1)
     assert result.out is True
 
 
 def test_callable_object_in_partial() -> None:
     """A functools.partial wrapping a callable object works without AttributeError."""
     func = partial(CallableObject())
-    result = wait_for(func, num_sec=1)
+    result = wait_for(func, timeout=1)
     assert result.out is True
 
 
@@ -98,11 +98,11 @@ def test_partial_as_func() -> None:
     incman = Incrementor()
     func = partial(lambda: incman.increment_with_sleep() > 10)
     with pytest.raises(TimedOutError):
-        wait_for(func, num_sec=2, delay=1)
+        wait_for(func, timeout=2, delay=1)
 
 
 # ---------------------------------------------------------------------------
-# timeout / num_sec parameter variants
+# timeout parameter variants
 # ---------------------------------------------------------------------------
 
 
@@ -118,14 +118,6 @@ def test_timeout_as_float() -> None:
     assert result.out is True
 
 
-def test_timeout_as_string() -> None:
-    """``timeout`` accepts a human-readable duration string (e.g. '2s')."""
-    incman = Incrementor()
-    func = partial(lambda: incman.increment_with_sleep() > 10)
-    with pytest.raises(TimedOutError):
-        wait_for(func, timeout="2s", delay=1)
-
-
 def test_timeout_as_timedelta() -> None:
     """``timeout`` accepts a :class:`datetime.timedelta`."""
     with pytest.raises(TimedOutError):
@@ -136,15 +128,6 @@ def test_timeout_unknown_type_raises() -> None:
     """``timeout`` with an unsupported type raises ``ValueError``."""
     with pytest.raises(ValueError, match="Timeout got an unknown value"):
         wait_for(_always_false, timeout=object())
-
-
-@pytest.mark.parametrize("value", ["2", "1.5"])
-def test_num_sec_as_string(value: str) -> None:
-    """``num_sec`` also accepts a string representation of a number."""
-    incman = Incrementor()
-    func = partial(lambda: incman.increment_with_sleep() > 10)
-    with pytest.raises(TimedOutError):
-        wait_for(func, num_sec=value)
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +142,7 @@ def test_callable_fail_condition() -> None:
         wait_for(
             incman.increment_with_sleep,
             fail_condition=lambda value: value <= 10,
-            num_sec=2,
+            timeout=2,
             delay=1,
         )
 
@@ -172,14 +155,14 @@ def test_set_fail_condition_success() -> None:
         counter[0] += 1
         return counter[0]
 
-    result = wait_for(increment, fail_condition={0, 1, 2}, delay=0, num_sec=5)
+    result = wait_for(increment, fail_condition={0, 1, 2}, delay=0, timeout=5)
     assert result.out == 3
 
 
 def test_set_fail_condition_timeout() -> None:
     """``fail_condition`` as a set: times out when the result is always in the set."""
     with pytest.raises(TimedOutError):
-        wait_for(_always_false, fail_condition={False}, num_sec=0.1, delay=0.05)
+        wait_for(_always_false, fail_condition={False}, timeout=0.1, delay=0.05)
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +177,7 @@ def test_silent_failure() -> None:
         lambda self: self.increment_with_sleep() > 100,
         [incman],
         delay=0.05,
-        num_sec=1,
+        timeout=1,
         silent_failure=True,
     )
     assert elapsed >= 1
@@ -204,7 +187,7 @@ def test_silent_failure() -> None:
 def test_log_on_loop() -> None:
     """``log_on_loop=True`` emits an info log on each polling iteration."""
     logger = MagicMock()
-    result = wait_for(_always_true, log_on_loop=True, logger=logger, num_sec=1)
+    result = wait_for(_always_true, log_on_loop=True, logger=logger, timeout=1)
     assert result.out is True
     logger.info.assert_called()
 
@@ -212,14 +195,14 @@ def test_log_on_loop() -> None:
 def test_expo_delay() -> None:
     """``expo=True`` doubles the inter-poll delay after each failed attempt."""
     with pytest.raises(TimedOutError):
-        wait_for(_always_false, expo=True, num_sec=0.15, delay=0.01)
+        wait_for(_always_false, expo=True, timeout=0.15, delay=0.01)
 
 
 def test_fail_func() -> None:
     """``fail_func`` is called after each unsuccessful polling attempt."""
     fail_func = MagicMock()
     with pytest.raises(TimedOutError):
-        wait_for(_always_false, fail_func=fail_func, num_sec=0.15, delay=0.05)
+        wait_for(_always_false, fail_func=fail_func, timeout=0.15, delay=0.05)
     assert fail_func.call_count >= 1
 
 
@@ -237,7 +220,7 @@ def test_fail_func_called_when_func_exhausts_timeout() -> None:
         return False
 
     with pytest.raises(TimedOutError):
-        wait_for(slow_fail, fail_func=fail_func, num_sec=0.1, delay=0)
+        wait_for(slow_fail, fail_func=fail_func, timeout=0.1, delay=0)
     assert fail_func.call_count == 1
 
 
@@ -253,7 +236,7 @@ def test_timeout_raises_timed_out_error() -> None:
         wait_for(
             lambda self: self.increment_with_sleep() > 10,
             [incman],
-            num_sec=1,
+            timeout=1,
             message="never_reached",
         )
 
@@ -263,7 +246,7 @@ def test_lambda_source_code_in_timeout_error(error_logger: MagicMock) -> None:
     """Lambda source code appears in both the ``TimedOutError`` message and the error log."""
     incman = Incrementor()
     with pytest.raises(TimedOutError) as excinfo:
-        wait_for(lambda self: self.increment_with_sleep() > 10, [incman], num_sec=1)
+        wait_for(lambda self: self.increment_with_sleep() > 10, [incman], timeout=1)
 
     expected = "lambda self: self.increment_with_sleep() > 10"
     assert expected in str(excinfo.value)
@@ -284,7 +267,7 @@ def test_builtin_timeout_error_message() -> None:
     exercising the else-branch of the filename/line_no guard in the timeout path.
     """
     with pytest.raises(TimedOutError) as exc_info:
-        wait_for(bool, [[]], num_sec=0.05, delay=0.01)
+        wait_for(bool, [[]], timeout=0.05, delay=0.01)
     assert "Could not do" in str(exc_info.value)
 
 
@@ -297,7 +280,7 @@ def test_decorator_with_kwargs() -> None:
     """``@wait_for_decorator(...)`` invoked with keyword arguments."""
     incman = Incrementor()
 
-    @wait_for_decorator(fail_condition=0, delay=0.05, num_sec=2)
+    @wait_for_decorator(fail_condition=0, delay=0.05, timeout=2)
     def a_test() -> int:
         return incman.increment_with_sleep()
 
@@ -309,7 +292,7 @@ def test_decorator_with_empty_parens() -> None:
     """``@wait_for_decorator()`` invoked with empty parentheses uses defaults."""
     incman = Incrementor()
 
-    @wait_for_decorator(num_sec=2)
+    @wait_for_decorator(timeout=2)
     def a_test() -> bool:
         return incman.increment_with_sleep() != 0
 
@@ -320,7 +303,7 @@ def test_decorator_with_empty_parens() -> None:
 def test_decorator_bare() -> None:
     """``@wait_for_decorator`` applied without parentheses uses defaults."""
 
-    @wait_for_decorator(num_sec=2)
+    @wait_for_decorator(timeout=2)
     def succeeds() -> bool:
         return True
 
@@ -338,7 +321,7 @@ def test_func_kwargs_forwarded() -> None:
     def check(*, threshold: int) -> int:
         return threshold
 
-    result = wait_for(check, func_kwargs={"threshold": 42}, num_sec=1)
+    result = wait_for(check, func_kwargs={"threshold": 42}, timeout=1)
     assert result.out == 42
 
 
@@ -348,7 +331,7 @@ def test_func_kwargs_combined_with_func_args() -> None:
     def add(a: int, b: int, *, offset: int = 0) -> int:
         return a + b + offset
 
-    result = wait_for(add, func_args=[1, 2], func_kwargs={"offset": 10}, num_sec=1)
+    result = wait_for(add, func_args=[1, 2], func_kwargs={"offset": 10}, timeout=1)
     assert result.out == 13
 
 
@@ -357,21 +340,18 @@ def test_func_kwargs_combined_with_func_args() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_timeout_none_falls_through_to_num_sec() -> None:
-    """``timeout=None`` is treated as if timeout was not provided; ``num_sec`` is used."""
-    with pytest.raises(TimedOutError):
-        wait_for(_always_false, timeout=None, num_sec=0.1, delay=0.05)
+def test_timeout_none_falls_through_to_default() -> None:
+    """``timeout=None`` resolves to the 120 s default."""
+    from wait_for import _get_timeout_secs
+
+    assert _get_timeout_secs({"timeout": None}) == 120.0
 
 
-# ---------------------------------------------------------------------------
-# Invalid time string
-# ---------------------------------------------------------------------------
+def test_timeout_not_provided_falls_through_to_default() -> None:
+    """Omitting ``timeout`` entirely resolves to the 120 s default."""
+    from wait_for import _get_timeout_secs
 
-
-def test_invalid_time_string_raises_value_error() -> None:
-    """An unparseable ``timeout`` string raises ``ValueError``."""
-    with pytest.raises(ValueError, match="Could not parse"):
-        wait_for(_always_true, timeout="not a valid time string xyz")
+    assert _get_timeout_secs({}) == 120.0
 
 
 # ---------------------------------------------------------------------------
@@ -381,21 +361,21 @@ def test_invalid_time_string_raises_value_error() -> None:
 
 def test_wait_for_result_index_access() -> None:
     """``WaitForResult`` supports index-based access for backward compatibility."""
-    result = wait_for(_always_true, num_sec=1)
+    result = wait_for(_always_true, timeout=1)
     assert result[0] is True
     assert isinstance(result[1], float)
 
 
 def test_wait_for_result_attribute_access() -> None:
     """``WaitForResult`` supports attribute-based access."""
-    result = wait_for(_always_true, num_sec=1)
+    result = wait_for(_always_true, timeout=1)
     assert result.out is True
     assert isinstance(result.duration, float)
 
 
 def test_wait_for_result_unpacking() -> None:
     """``WaitForResult`` supports tuple unpacking."""
-    out, duration = wait_for(_always_true, num_sec=1)
+    out, duration = wait_for(_always_true, timeout=1)
     assert out is True
     assert isinstance(duration, float)
 
@@ -406,40 +386,40 @@ def test_wait_for_result_unpacking() -> None:
 
 
 def test_expo_sleep_does_not_overshoot_timeout() -> None:
-    """With ``expo=True``, elapsed time must not significantly exceed ``num_sec``.
+    """With ``expo=True``, elapsed time must not significantly exceed ``timeout``.
 
     The exponential delay doubles each iteration and can grow well past the
     remaining time budget.  The wait loop should cap each sleep to the time
-    left so the total wall-clock duration stays close to ``num_sec``.
+    left so the total wall-clock duration stays close to ``timeout``.
     """
-    num_sec = 2.0
+    timeout = 2.0
     tolerance = 0.5
     _, duration = wait_for(
         _always_false,
         expo=True,
         delay=0.1,
-        num_sec=num_sec,
+        timeout=timeout,
         silent_failure=True,
     )
-    assert duration <= num_sec + tolerance, (
-        f"Expected <= {num_sec + tolerance}s, but waited {duration:.2f}s"
+    assert duration <= timeout + tolerance, (
+        f"Expected <= {timeout + tolerance}s, but waited {duration:.2f}s"
     )
 
 
 def test_large_fixed_delay_does_not_overshoot_timeout() -> None:
-    """A fixed ``delay`` larger than ``num_sec`` must not cause a long overshoot.
+    """A fixed ``delay`` larger than ``timeout`` must not cause a long overshoot.
 
     When delay exceeds the remaining budget, the sleep should be capped so
-    the total elapsed time stays close to ``num_sec``.
+    the total elapsed time stays close to ``timeout``.
     """
-    num_sec = 0.5
+    timeout = 0.5
     tolerance = 0.5
     _, duration = wait_for(
         _always_false,
         delay=10,
-        num_sec=num_sec,
+        timeout=timeout,
         silent_failure=True,
     )
-    assert duration <= num_sec + tolerance, (
-        f"Expected <= {num_sec + tolerance}s, but waited {duration:.2f}s"
+    assert duration <= timeout + tolerance, (
+        f"Expected <= {timeout + tolerance}s, but waited {duration:.2f}s"
     )

--- a/tests/test_wait_for.py
+++ b/tests/test_wait_for.py
@@ -340,6 +340,12 @@ def test_func_kwargs_combined_with_func_args() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_num_sec_raises_type_error() -> None:
+    """Passing the removed ``num_sec`` kwarg raises ``TypeError`` immediately."""
+    with pytest.raises(TypeError, match="use 'timeout' instead"):
+        wait_for(_always_true, num_sec=30)
+
+
 def test_timeout_none_falls_through_to_default() -> None:
     """``timeout=None`` resolves to the 120 s default."""
     from wait_for import _get_timeout_secs

--- a/uv.lock
+++ b/uv.lock
@@ -3,20 +3,5 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "parsedatetime"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/20/cb587f6672dbe585d101f590c3871d16e7aec5a576a1694997a3777312ac/parsedatetime-2.6.tar.gz", hash = "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455", size = 60114, upload-time = "2020-05-31T23:50:57.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl", hash = "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b", size = 42548, upload-time = "2020-05-31T23:50:56.315Z" },
-]
-
-[[package]]
 name = "wait-for"
 source = { editable = "." }
-dependencies = [
-    { name = "parsedatetime" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "parsedatetime", specifier = ">=2.5" }]

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -4,15 +4,11 @@ import inspect
 import logging
 import time
 from collections.abc import Callable, Iterable
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import partial
 from threading import Timer
 from types import LambdaType
 from typing import Any, NamedTuple
-
-import parsedatetime
-
-calendar: parsedatetime.Calendar = parsedatetime.Calendar()
 
 
 class WaitForResult(NamedTuple):
@@ -34,28 +30,15 @@ default_hidden_logger.propagate = False
 default_hidden_logger.addHandler(logging.NullHandler())
 
 
-def _parse_time(t: str) -> float:
-    parsed, code = calendar.parse(t)
-    if code != 2:
-        raise ValueError(f"Could not parse {t}!")
-    parsed = datetime.fromtimestamp(time.mktime(parsed))
-    return (parsed - datetime.now()).total_seconds()
-
-
 def _get_timeout_secs(kwargs: dict[str, Any]) -> float:
-    if "timeout" in kwargs and kwargs["timeout"] is not None:
-        timeout = kwargs["timeout"]
-        if isinstance(timeout, (int, float)):
-            num_sec = float(timeout)
-        elif isinstance(timeout, str):
-            num_sec = _parse_time(timeout)
-        elif isinstance(timeout, timedelta):
-            num_sec = timeout.total_seconds()
-        else:
-            raise ValueError(f"Timeout got an unknown value {timeout}")
-    else:
-        num_sec = float(kwargs.get("num_sec", 120))
-    return num_sec
+    timeout = kwargs.get("timeout", None)
+    if timeout is None:
+        return 120.0
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    if isinstance(timeout, timedelta):
+        return timeout.total_seconds()
+    raise ValueError(f"Timeout got an unknown value {timeout!r}")
 
 
 def is_lambda_function(obj: object) -> bool:
@@ -160,12 +143,9 @@ def wait_for(
         func (callable): A function to be run
         func_args (Iterable[Any]): A list of function arguments to be passed to func
         func_kwargs (dict[str, Any]): A dict of function keyword arguments to be passed to func
-        num_sec (int): An int describing the number of seconds to wait before timing out.
-        timeout (Union[int, timedelta, str]): Describes time to wait before timing out.
-            Either an int describing the number of seconds.
-            Or a :py:class:`timedelta` object.
-            Or a string formatted like ``1h 10m 5s``.
-            This then sets the ``num_sec`` variable.
+        timeout (Union[int, float, timedelta]): Maximum time to wait before timing out.
+            Either an int/float describing the number of seconds, or a
+            :py:class:`timedelta` object. Defaults to 120 seconds when not provided.
         expo (Any): A flag toggling exponential delay growth.
         message (Optional[str]): A description of func's operation. If None, defaults to the
             function's name.
@@ -205,7 +185,7 @@ def wait_for(
               (measured with :py:func:`time.monotonic`) until ``func()`` succeeded,
               or until the timeout was reached when ``silent_failure=True``.
     Raises:
-        TimedOutError: If num_sec is exceeded after an unsuccessful func() invocation and silent
+        TimedOutError: If timeout is exceeded after an unsuccessful func() invocation and silent
             failure is not set
     """
     # Hide this call in the detailed traceback
@@ -339,7 +319,7 @@ def wait_for_decorator(*args: Any, **kwargs: Any) -> Any:
     It passes the function decorated to ``wait_for``
     Example:
     .. code-block:: python
-        @wait_for_decorator(num_sec=120)
+        @wait_for_decorator(timeout=120)
         def my_waiting_func():
             return do_something()
     You can also pass it without parameters, then it uses ``wait_for``'s defaults:

--- a/wait_for/__init__.py
+++ b/wait_for/__init__.py
@@ -191,6 +191,10 @@ def wait_for(
     # Hide this call in the detailed traceback
     # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
     __tracebackhide__ = True
+    if "num_sec" in kwargs:
+        raise TypeError(
+            "wait_for() got an unexpected keyword argument 'num_sec'; use 'timeout' instead"
+        )
     if func_args is None:
         func_args = []
     if func_kwargs is None:


### PR DESCRIPTION
Consolidate on the timeout kwarg, simplifying some logic

Remove parsedatetime dependency and only process int/float/timedelta objects in timeout kwarg